### PR TITLE
handle CRLF or LF when parsing contacts

### DIFF
--- a/src/vc_scan.l
+++ b/src/vc_scan.l
@@ -67,7 +67,7 @@ NAME-CHAR       [\x21-\x2B\x2D\x2F-\x39\x3C\x3E-\x5A\x5C\x5E-\x7E]
 
 <SC_VALUE>
 {
-({VALUE-CHAR}|"\n ")*     { yylval = yytext; return TOK_VALUE; }
+({VALUE-CHAR}|"\n "|"\r\n ")*     { yylval = yytext; return TOK_VALUE; }
 "\n"                      { yylval = NULL; BEGIN(INITIAL); return yytext[0]; }
 }
 


### PR DESCRIPTION
This PR adds an option for lines ending in CRLF to the Grammar for vcf files

fixes #2 